### PR TITLE
updating readme with missing gsl dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,19 @@ Authors: Rafael Brahm, Andrés Jordán, Néstor Espinoza
 The principal goal of CERES is the developement of fully automated pipelines for the reduction, extraction and analysis of echelle spectrograph data. CERES currently counts with dedicated pipelines for eleven different instruments, which are included in the repository: APO3.5m/ARCES, CAHA2.2m/CAFE, Euler1.2m/Coralie, DuPont2.5m/Echelle, MPG2.2m/FEROS, ESO1.0m/FIDEOS, ESO3.6m/HARPS, KECK10m/HIRES, MAGELLAN6.5m/MIKE, MALLEGAN6.5m/PFS, PUC0.5m/PUCHEROS. These processing recipes can be used as a reference for developing pipelines for new instruments. A detailed decription of the structure and performance of these pipelines can be found in [Brahm et al 2016](http://arxiv.org/abs/1609.02279). The standard output of the pipelines is a fits cube with the optimally extracted, wavelength calibrated and instrumetal drift corrected spectrum for each of the science images. Additionally, CERES includes routines for the computation of precise radial velocities and bisector spans via the cross-correlation method, and an automated algorithm to obtain an estimate of the atmospheric parameters of the observed star.
 
 # Usage
-In order to run one of the pipelines, you have to be in the CERES directory where the pipeline for the instrument of interest lies and run the corresponding ```Python''' pipe code followed by the path to the raw data. For example, in the case of the FEROS pipeline you have to enter:
+In order to run one of the pipelines, you have to be in the CERES directory where the pipeline for the instrument of interest lies and run the corresponding:
 
-    $ cd ceres/feros
-    $ python ferospipe.py /path/to/the/raw/data/to/be/processed
+
+```
+python INSTRUMENTpipe.py
+```
+
+code followed by the path to the raw data. For example, in the case of the FEROS pipeline you have to enter:
+
+```
+cd ceres/feros
+python ferospipe.py /path/to/the/raw/data/to/be/processed
+```
 
 Additionally you can specify some options in order to modify some of the processing steps. The available options are:
 
@@ -26,11 +35,13 @@ Additionally you can specify some options in order to modify some of the process
                     located in the directory where the raw data is.
     -ofind          only valid for slit spectrographs. Name of the image that will be used to identify
                     and trace the echelle orders.
-    
+
 For example, if you want your output directory to bee foo/, you don't want to generate the CCF plots, you want to perform the spectral classification, you want to use 10 CPU cores, and you want to process only the data of the target called HATS-17, then you would do:
 
-    $ python ferospipe.py /path/to/the/raw/data/to/be/processed -dirout foo/ -avoid_plot -do_class -npools 10 -o2do HATS-17
-    
+```
+python ferospipe.py /path/to/the/raw/data/to/be/processed -dirout foo/ -avoid_plot -do_class -npools 10 -o2do HATS-17
+```
+
 The auxiliary file mentioned above (reffile) corresponds to a plain text file that can be used to give data for particular targets in order to improve the precision in the radial velocity estimation. The file should contain 8 comma-sparated colummns containing the following information:
 
     1-  name of the target as specified in the image header.
@@ -42,14 +53,14 @@ The auxiliary file mentioned above (reffile) corresponds to a plain text file th
         If 1, the code uses the coordinates given in this file.
     7-  mask that will be used to compute the CCF. Allowed entries are G2, K5 and M2.
     8-  velocity width in km/s that is used to broaden the lines of the binary mask.
-        It should be similar to the standard deviation of the Gaussian that is fitted to the CCF. 
-        
+        It should be similar to the standard deviation of the Gaussian that is fitted to the CCF.
+
 Here is an example of a reffile:
 
     HD157347,17:22:51.28809,-02:23:17.4297,49.39,-107.16,1,G2,4.0
     HD32147,05:00:48.99977,-05:45:13.2303,550.12,-1109.23,1,G2,4.0
     HD72673,08:32:51.49609,-31:30:03.0717,-1113.37,761.57,1,K5,4.0
-    
+
 If the pipeline doesn't find any reffile, it uses the coordinates found in the image header to compute the barycentric correction and uses the G2 mask to compute the CCF.
 
 Additionally, there are other two auxiliary files that can be placed in the same directory of the raw images for improving the reductions. A file called 'bad_files.txt' can be used to list all the images of the raw directory that should be ignored by the pipeline. Each line of the bad_files file must have the name of the image without the complete path. Another file named 'moon_corr.txt' can be used to specify the images for which the CCF computation will include a double gaussian fit in order to correct the radial velocity for the effects of scattered moonlight contamination.
@@ -57,11 +68,9 @@ Additionally, there are other two auxiliary files that can be placed in the same
 # Output
 While the directory specified in the dirout directory will contain several intermediate reduction files, the final results will be placed in the directory 'proc/'. This directory can contain up to three types of files:
 
-1) .fits files with the extracted and wavelength calibrated spectra.
-
-2) .pdf files that show the CCF plots.
-
-3) a text file (results.txt) that contains a summary of the results of the reduction including the radial velocity measurements and the atmospheric parameters.
+   1. .fits files with the extracted and wavelength calibrated spectra.
+   1. .pdf files that show the CCF plots.
+   1. a text file (results.txt) that contains a summary of the results of the reduction including the radial velocity measurements and the atmospheric parameters.
 
 The .fits files are data cubes with dimensions (10,nords,npix), where nords are the total number of processed echelle orders, and npix in the number of pixels in the dispersion direction. The ten entries in the first dimension correspond to:
 
@@ -101,11 +110,30 @@ The colummns in the results.txt file are the following:
 # Dependencies
 CERES has been succesfully tested with python2.6 and python2.7 on OS X and Linux systems.
 
-Some python packages need to be installed: python-numpy, python-scipy, python-matplotlib, python-pyfits, python-pycurl, python-ephem, python-rpy2.
+Some python packages need to be installed:
 
-Additionally, SWIG and the gcc, g++, gfortran compilers are required.
+   1. python-numpy
+   1. python-scipy
+   1. python-matplotlib
+   1. python-pyfits
+   1. python-pycurl
+   1. python-ephem
+   1. python-rpy2 (depends on R)
 
-    
+All of the above can be installed using pip, e.g.:
+
+```pip install numpy, scipy, matplotlib, pyfits, pycurl, ephem, rpy2```
+
+Additionally:
+
+   1. SWIG
+   1. gcc, g++, gfortran
+   1. gsl
+
+are required. All of the above can be install using homebrew on OSX, e.g.:
+
+```brew install swig, gcc, gsl```
+
 # Installation
 The python code does not need any previous installation. However, CERES uses some C, C++, and fortran routines that must be compiled in order to be called from python by the pipelines. Before installation it is necessary to check and modify some variables of the installation files of these codes.
 
@@ -116,12 +144,9 @@ SSephem requires also three separete files for running: the binary solar system 
 
 After checking the C, C++, and fortran installation files, CERES can be istalled with the following command:
 
-    $ python install.py
-    
+```python install.py```
+
 For uninstalling CERES you can enter:
 
-    $ python clean.py
-    
-
-
+```python clean.py```
 


### PR DESCRIPTION
hi, 
This is excellent timing for your paper and code, thanks very much. I had started to write a similar package myself but it was becoming quite involved. I've just installed the software and spotted a dependency was missing. When making `Continuum` the installation was complaining about missing `-lgsl`.  See below for the error message:

```
     > C code found in directory utils/Continuum. Building...                                                                                                                           [1044/4586]
     ----------------------------------------------------------
     > ERROR: CERES couldn't be installed.
     > Problem building code in utils/Continuum. The error was:

                In file included from FunNorm.c:2:
                In file included from /Users/James/.pyenv/versions/miniconda-latest/lib/python2.7/site-packages/numpy/core/include/numpy/arrayobject.h:4:
                In file included from /Users/James/.pyenv/versions/miniconda-latest/lib/python2.7/site-packages/numpy/core/include/numpy/ndarrayobject.h:18:
                In file included from /Users/James/.pyenv/versions/miniconda-latest/lib/python2.7/site-packages/numpy/core/include/numpy/ndarraytypes.h:1777:
                /Users/James/.pyenv/versions/miniconda-latest/lib/python2.7/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: "Using deprecated NumPy API, disable it 
by "          "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-W#warnings]
                #warning "Using deprecated NumPy API, disable it by " \
                 ^
                In file included from FunNorm.c:2:
                In file included from /Users/James/.pyenv/versions/miniconda-latest/lib/python2.7/site-packages/numpy/core/include/numpy/arrayobject.h:4:
                In file included from /Users/James/.pyenv/versions/miniconda-latest/lib/python2.7/site-packages/numpy/core/include/numpy/ndarrayobject.h:27:
                /Users/James/.pyenv/versions/miniconda-latest/lib/python2.7/site-packages/numpy/core/include/numpy/__multiarray_api.h:1448:1: warning: unused function '_import_array' [-Wunused-fu
nction]
                _import_array(void)
                ^
                2 warnings generated.
                ld: library not found for -lgsl
                clang: error: linker command failed with exit code 1 (use -v to see invocation)
                error: command 'gcc' failed with exit status 1
```

I am using OSX El Capitan and got `gsl` via Homebrew. Hopefully this tweak to the README file is ok. Thanks again. 

Cheers
James 
