### PR TITLE
Updated SSEphem Makefile for OSX venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,13 @@ The python code does not need any previous installation. However, CERES uses som
 
 First, it must be checked if the default f2py version is compatible with the default python version. If that is not the case, the files named "Proceso_f2py" in ceres/utils/CCF and ceres/utils/BaryCor should be modified in order to point to the compatible f2py binary file.
 
-CERES uses the [SSephem](http://www.cv.nrao.edu/~rfisher/Python/py_solar_system.html) package coupled to the [SOFA](http://www.iausofa.org/) C functions for computing the barycentric velocity corrections. A version of this package with minor modifications is included in the CERES repository. In order to install this package, it has to be checked that the ceres/utils/SSephem/Makefile points to the correct Python, SWIG, and numpy paths.
+CERES uses the [SSephem](http://www.cv.nrao.edu/~rfisher/Python/py_solar_system.html) package coupled to the [SOFA](http://www.iausofa.org/) C functions for computing the barycentric velocity corrections. A version of this package with minor modifications is included in the CERES repository. In order to install this package, it has to be checked that the ceres/utils/SSephem/Makefile points to the correct Python, SWIG, and numpy paths. Edit the lines:
+
+```
+PY_PREFIX := /usr/local
+SWIG = /usr/local/bin/swig
+```
+
 SSephem requires also three separete files for running: the binary solar system ephemeris, a leap-second table, and a UT1 - UTC offset table. These three files are downloaded during the CERES installation. However, the latter two files should be periodically updated, which can be easily done by reinstalling CERES.
 
 After checking the C, C++, and fortran installation files, CERES can be istalled with the following command:

--- a/install.py
+++ b/install.py
@@ -105,7 +105,7 @@ def Build(directory):
            print "     > C code found in directory "+directory+". Building..."
            cwd = os.getcwd()
            os.chdir(directory)
-           p = subprocess.Popen('python setup.py build',stdout = subprocess.PIPE, stderr = subprocess.PIPE,shell = True)
+           p = subprocess.Popen('{python} setup.py build'.format(python=sys.executable),stdout = subprocess.PIPE, stderr = subprocess.PIPE,shell = True)
            p.wait()
            if(p.returncode != 0 and p.returncode != None):
              print "     ----------------------------------------------------------"

--- a/utils/SSEphem/Makefile
+++ b/utils/SSEphem/Makefile
@@ -4,10 +4,10 @@
 
 # Update this line!
 PY_PREFIX := /usr/local
+SWIG = /usr/local/bin/swig
 
 # Do not change below here
 PY  = $(PY_PREFIX)/include/python2.7/
-SWIG = /usr/local/bin/swig
 INUM = $(PY_PREFIX)/lib/python2.7/site-packages/numpy/core/include/numpy/
 ISOFA = ./SOFA
 LSOFA = ./SOFA/lib

--- a/utils/SSEphem/Makefile
+++ b/utils/SSEphem/Makefile
@@ -2,17 +2,27 @@
 # Makefile for Python wrapper and test programs associated with the
 # JPL DE403 ephemerides.
 
-PY  = /usr/include/python2.7/
-SWIG = /usr/local/Cellar/swig/2.0.12/bin/swig
-INUM = /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/numpy/core/include/numpy/
+# Update this line!
+PY_PREFIX := /usr/local
+
+# Do not change below here
+PY  = $(PY_PREFIX)/include/python2.7/
+SWIG = /usr/local/bin/swig
+INUM = $(PY_PREFIX)/lib/python2.7/site-packages/numpy/core/include/numpy/
 ISOFA = ./SOFA
 LSOFA = ./SOFA/lib
 CPP = g++ -fPIC
 
+POSTSTEP =
+ifeq ($(shell uname),Darwin)
+    # XXX disgusting
+    POSTSTEP = install_name_tool -change libpython2.7.dylib $(PY_PREFIX)/lib/libpython2.7.dylib _jplephem.so
+endif
+
 #INCLUDE = -I. -I$(ISLALIB)
 INCLUDE = -I. -I$(ISOFA)
 #LIBRARIES = -L$(LSLALIB)
-LIBRARIES = -L$(LSOFA)
+LIBRARIES = -L$(LSOFA) -L$(PY_PREFIX)/lib
 
 OBJ_FILES = jplephem.o\
 	    python_client_fn.o \
@@ -55,6 +65,7 @@ all: $(EXECUTABLES)
 _jplephem.so : jplephem_wrap.o $(OBJ_FILES)
 	$(CPP) -lpython2.7 -shared jplephem_wrap.o $(OBJ_FILES) $(LIBRARIES) \
 					-lsofa_c -o _jplephem.so
+	$(POSTSTEP)
 
 jplephem_wrap.o : jplephem_wrap.c jplephem.h
 	$(CPP) jplephem_wrap.c -c -g -I$(PY)/Include -I$(PY) $(INCLUDE) \


### PR DESCRIPTION
The `_jplephem.so` file was not being linked correctly to the right version of Python. This meant `import jplephem` would crash and burn with a `Fatal Python error: PyThreadState_Get: no current thread` error, see #3. 

The change to the Makefile alters the `_jplephem.so` file to point to the right python installation. The change affects OSX only.  

The change to `install.py` explicitly sets the python version for `python setup.py build` to be the same as that used for `python install.py`

Thanks to @mindriot101 and @pchote for their help in fixing this. 
